### PR TITLE
LoadUserProfile is not supported on linux platform

### DIFF
--- a/Solution/FastHashes/Hash.cs
+++ b/Solution/FastHashes/Hash.cs
@@ -34,7 +34,6 @@ namespace FastHashes
                 CreateNoWindow = true,
                 ErrorDialog = false,
                 FileName = "uname",
-                LoadUserProfile = false,
                 RedirectStandardOutput = true,
                 UseShellExecute = false
             };


### PR DESCRIPTION
LoadUserProfile defaults to false, remove it because it is not supported on Linux

It defaults to `false` though

https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.loaduserprofile?view=netcore-3.1#property-value

<!--- Provide a general summary of your changes above. -->

## Description

## Motivation and Context

## Implementation

was contemplating first to add

```
var isWindows=System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
if(isWindows){
```

but given that `false` is the default it didn't make much sense to me
